### PR TITLE
Fix Netlify build error by specifying base directory

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  base = "project"


### PR DESCRIPTION
Netlify was failing to find package.json because it was located in the 'project/' subdirectory. This change adds a netlify.toml file to the root directory, configuring Netlify to use 'project/' as the base directory for builds.